### PR TITLE
コマンドのタイムアウトとFIFOサイズの設定

### DIFF
--- a/esp32_socket.py
+++ b/esp32_socket.py
@@ -26,7 +26,7 @@ def main(q):
             conn, addr = listenSocket.accept()  # 接続を受信
             print(addr, "connected")
             try:
-                command = q.get()
+                command = q.get(timeout=300)
                 print(f'Socket:{command}')
                 if len(command) > 0:
                     conn.sendall(command.encode())

--- a/shutter_control_server.py
+++ b/shutter_control_server.py
@@ -5,7 +5,7 @@ import esp32_socket
 import json
 
 
-q = queue.Queue()
+q = queue.Queue(maxsize=2)
 
 app = Flask(__name__)
 


### PR DESCRIPTION
ESP32がSocket接続したままメッセージのやり取りがない状態で長時間（３０分程度）経過すると意図せず検知されないまま接続が切断されてしまうバグに対してタイムアウトと制御コマンドQueueのFIFOのサイズを設定。